### PR TITLE
Add CITATION.cff for HeritageGraph Ontology

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,48 @@
+cff-version: 1.2.0
+title: "HeritageGraph Ontology"
+message: "If you use this ontology, please cite it using the metadata below."
+type: dataset
+
+authors:
+
+* family-names: "Karki"
+  given-names: "Niraj"
+
+* family-names: "Oli"
+  given-names: "Nabin"
+
+* family-names: "Sapkota"
+  given-names: "Anu"
+
+* family-names: "Yumusak"
+  given-names: "Semih"
+
+* family-names: "Chhetri"
+  given-names: "Tek Raj"
+
+version: "1.0.0"
+date-released: "2026-01-01"
+
+publisher: "CAIR-Nepal"
+
+repository-code: "https://github.com/CAIRNepal/heritagegraphontology"
+url: "https://cairnepal.github.io/heritagegraphontology/"
+
+license: "CC-BY-4.0"
+
+keywords:
+
+* ontology
+* semantic web
+* cultural heritage
+* heritage knowledge graph
+* linked data
+* owl
+* rdf
+* nepal
+
+abstract: >
+HeritageGraph is an event-centric OWL ontology for representing
+Nepalese cultural heritage, including tangible and intangible
+heritage assets, sacred places, rituals, festivals, institutions,
+communities, and the relationships that connect them.


### PR DESCRIPTION
This file contains citation metadata for the HeritageGraph Ontology, including authors, version, publisher, and keywords.